### PR TITLE
Only wait for network awaked

### DIFF
--- a/zwave_mqtt_bridge
+++ b/zwave_mqtt_bridge
@@ -135,10 +135,10 @@ def main():
     observer.start()
 
     print("Waiting for network")
-    while network.state != network.STATE_READY:
+    while network.state != network.STATE_AWAKED:
         time.sleep(1)
 
-    print("Network ready")
+    print("Network awake")
 
     # Connect to events
     def value_updated(network, node, value):


### PR DESCRIPTION
Nodes in a network can be queried after STATE_AWAKED, not needing to wait for (possibly dead) nodes.